### PR TITLE
[skin_default.xml] Use buttons/vkey_ image

### DIFF
--- a/skin_default.xml
+++ b/skin_default.xml
@@ -2147,7 +2147,7 @@ self.autoResize()
 		<widget name="videomode" position="10,10" size="230,40" font="Regular;23" halign="left"/>
 	</screen>
 	<screen name="VirtualKeyBoard" position="center,center" size="650,375" zPosition="99">
-		<ePixmap pixmap="vkey_text.png" position="5,35" zPosition="-4" size="640,50" alphatest="on"/>
+		<ePixmap pixmap="buttons/vkey_text.png" position="5,35" zPosition="-4" size="640,50" alphatest="on"/>
 		<widget name="header" position="10,10" size="630,25" font="Regular;20" transparent="1" noWrap="1" conditional="header"/>
 		<widget name="prompt" position="10,10" size="630,25" font="Regular;20" transparent="1" noWrap="1" conditional="prompt"/>
 		<widget name="text" position="10,35" size="630,50" font="Regular;40" transparent="1" noWrap="1" halign="right" valign="center"/>


### PR DESCRIPTION
Change the VirtualKeyBoard screen to use the images in the "buttons" subdirectory.

The images at the top level are a legacy from MediaPortal that could change or go away.
